### PR TITLE
Fix input line height

### DIFF
--- a/packages/Input/index.vue
+++ b/packages/Input/index.vue
@@ -193,11 +193,13 @@ export default {
 
 .large > input {
   font-size: $fs-16;
+  line-height: 48px;
   height: 48px;
 }
 
 .medium > input {
   font-size: $fs-14;
+  line-height: 36px;
   height: 36px;
 }
 


### PR DESCRIPTION
To prevent multi-line display of input field in iPhone UIWebView.

![IMG_F8F9A314D7C1-1](https://user-images.githubusercontent.com/579145/75127605-f1659300-56fa-11ea-9e89-8827fcf2f99f.jpeg)
